### PR TITLE
<design> : 캘린더overflow 스크롤 적용, 전체 레이아웃 그림자효과, 타이틀 컴포넌트 css수정

### DIFF
--- a/app/components/Calendar/MonthlyCalender.tsx
+++ b/app/components/Calendar/MonthlyCalender.tsx
@@ -93,7 +93,7 @@ export default function MonthlyCalender() {
   };
 
   return (
-    <div className="bg-white p-2.5 font-mono">
+    <div className="bg-white p-2.5">
       <section className="h-[300px]">
         <nav className="flex items-center justify-between py-2.5 px-6 h-1/5">
           <button onClick={movePrevMonth}>

--- a/app/components/NavLayout.tsx
+++ b/app/components/NavLayout.tsx
@@ -4,7 +4,7 @@ import NavBar from "./NavBar";
 export default function NavLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="w-full h-full flex flex-col">
-      <section className="w-full h-full">{children}</section>
+      <section className="w-full h-full overflow-auto">{children}</section>
       <NavBar />
     </div>
   );

--- a/app/components/Titletxt.tsx
+++ b/app/components/Titletxt.tsx
@@ -1,14 +1,10 @@
 interface TitleTxtProps {
   titleTxt: string;
-  center?: "text-center" | null;
 }
 
-export default function TitleTxt({
-  titleTxt,
-  center = "text-center",
-}: TitleTxtProps) {
+export default function TitleTxt({ titleTxt }: TitleTxtProps) {
   return (
-    <h1 className={`mt-12 mb-12 text-xl font-extrabold ${center}`}>
+    <h1 className={`mt-8 mb-8 text-xl font-extrabold text-center`}>
       {titleTxt}
     </h1>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,7 +21,9 @@ export default function RootLayout({
     <html>
       <body className={`w-screen h-screen ${fonts.className}`}>
         <main className="w-full h-full flex justify-center">
-          <div className="w-full h-full max-w-screen-md">{children}</div>
+          <div className="w-full h-full max-w-screen-md shadow-lg gray-500/50">
+            {children}
+          </div>
         </main>
       </body>
     </html>

--- a/app/record/page.tsx
+++ b/app/record/page.tsx
@@ -1,12 +1,14 @@
 import MonthlyCalender from "../components/Calendar/MonthlyCalender";
+import NavLayout from "../components/NavLayout";
 import Titletxt from "../components/Titletxt";
 
 export default function Record() {
   return (
-    // w88-352px, 22rem
-    <div className="w-88 h-fit p-2.5 flex flex-col">
+    <NavLayout>
+      {/*<div className="w-88 h-fit p-2.5 flex flex-col">*/}
       <Titletxt titleTxt="혈당 기록" />
       <MonthlyCalender />
-    </div>
+      {/*</div>*/}
+    </NavLayout>
   );
 }


### PR DESCRIPTION
1. navlayout적용시 캘린더 페이지에서 height가 navbar넘어가는 문제점을 수정(overflow 스크롤 적용)
2. 전체 레이아웃 그림자효과를 주어 구분감을 줌.
3. 타이틀 컴포넌트에서 text가 가운데로 오도록 수정