### PR TITLE
<design> : Chart 페이지 flex-wrap 등 스타일 수정

### DIFF
--- a/app/chart/page.tsx
+++ b/app/chart/page.tsx
@@ -1,13 +1,16 @@
 import NavLayout from "../components/NavLayout";
 import ChartForm from "../components/Chart/ChartForm";
+import TitleTxt from "../components/Titletxt";
 
 export default function Chart() {
   return (
     <NavLayout>
-      <h2 className="text-xl font-extrabold text-left w-full indent-3.5">
-        혈당 차트
-      </h2>
+      <TitleTxt titleTxt="혈당 차트" />
       <ChartForm />
+      <img
+        src="/image/chartRecommended.jpg"
+        alt="혈당의 정상 수치 및 조절 목표를 설명하는 표입니다. 공복일 때의 정상 혈당 수치는 70~100 mg/dL 식후 2시간 이후부터의 정상 혈당 수치는 90~140 mg/dL 입니다. 공복일 때의 혈당 수치는 80~130 mg/dL를, 식후 2시간 이후부터의 혈당 수치는 180 mg/dL 이하로 조절하는 것을 목표로 합니다."
+      />
     </NavLayout>
   );
 }

--- a/app/components/Chart/ChartForm.tsx
+++ b/app/components/Chart/ChartForm.tsx
@@ -30,8 +30,8 @@ export default function ChartForm() {
   });
 
   return (
-    <form className="w-full h-full" onChange={checkHandler}>
-      <ul className="flex gap-2 w-full justify-end my-2.5 pr-5">
+    <form className="w-full" onChange={checkHandler}>
+      <ul className="flex gap-2 w-full justify-end mb-6 pr-5 flex-wrap">
         {dateCategory.map((category) => {
           return (
             <ChartCategory
@@ -44,7 +44,7 @@ export default function ChartForm() {
         })}
       </ul>
       <ChartGraph XKey={category.날짜} YKey={category.시간} />
-      <ul className="flex gap-2 w-full justify-center my-9">
+      <ul className="flex gap-2 w-full justify-center my-9 flex-wrap">
         {timeCategory.map((category) => {
           return (
             <ChartCategory
@@ -56,10 +56,6 @@ export default function ChartForm() {
           );
         })}
       </ul>
-      <img
-        src="/image/chartRecommended.jpg"
-        alt="혈당의 정상 수치 및 조절 목표를 설명하는 표입니다. 공복일 때의 정상 혈당 수치는 70~100 mg/dL 식후 2시간 이후부터의 정상 혈당 수치는 90~140 mg/dL 입니다. 공복일 때의 혈당 수치는 80~130 mg/dL를, 식후 2시간 이후부터의 혈당 수치는 180 mg/dL 이하로 조절하는 것을 목표로 합니다."
-      />
     </form>
   );
 }

--- a/app/components/Chart/ChartGraph.tsx
+++ b/app/components/Chart/ChartGraph.tsx
@@ -15,7 +15,7 @@ interface Props {
 
 export default function ChartGraph({ XKey, YKey }: Props) {
   return (
-    <ResponsiveContainer width="100%" height="50%">
+    <ResponsiveContainer width="100%" height={300}>
       <LineChart
         width={500}
         height={300}
@@ -28,7 +28,7 @@ export default function ChartGraph({ XKey, YKey }: Props) {
         }}
       >
         <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="날짜" tickFormatter={formatX} />
+        <XAxis dataKey="날짜" tickFormatter={formatX} dy={10} />
         <YAxis
           tickCount={10}
           domain={[20, 200]}


### PR DESCRIPTION
flex-wrap을 적용해 화면이 축소되더라도 버튼들을 이용할 수 있게끔 수정했습니다.

form의 height가 기존의 100%였던 것을 컨텐츠에 따라 조절되도록 해당 속성을 삭제했습니다.

이후 반응형 차트가 높이를 인식하지 못해, 높이를 고정값으로 300px 부여했습니다.