### PR TITLE
<fix> : 메모등록시 서버 오류 수정

### DIFF
--- a/app/components/InfoTab/MemoHistory.tsx
+++ b/app/components/InfoTab/MemoHistory.tsx
@@ -8,7 +8,6 @@ interface MemoHistoryProps {
 export default function memoHistory({ dateStr }: MemoHistoryProps) {
   const selectedDay = dateStr.split("-");
   const [memoValue, setMemoValue] = useState<string>("");
-  //const [memoData];
 
   const getMemoData = async () => {
     try {
@@ -28,27 +27,29 @@ export default function memoHistory({ dateStr }: MemoHistoryProps) {
 
   useEffect(() => {
     getMemoData();
-  }, []);
+  }, [dateStr]);
+
+  const handleMemoChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const { value } = event.target;
+    setMemoValue(value);
+  };
 
   const handleMemoSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
     try {
+      console.log(dateStr);
       const response = await authApiService.put(
         `/api/management/${selectedDay[0]}/${selectedDay[1]}/${selectedDay[2]}/feedback/`,
-        { content: memoValue }
+        { content: memoValue, created_at: dateStr }
       );
+
       if (response.status === 200) {
-        await getMemoData();
+        console.log("성공", response.data);
       }
     } catch (error: any) {
       console.log("메모를 등록하지 못했습니다: ", error.message);
     }
-  };
-
-  const handleMemoChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const { value } = event.target;
-    setMemoValue(value);
   };
 
   return (

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -35,9 +35,7 @@ export default function Login() {
   const isFormValid = isValid.email && isValid.password;
 
   const handleAuthInputChange = (e: any) => {
-    // 입력 값 업데이트
     const { value, name } = e.target;
-    console.log(e.target);
     setAuthInp({
       ...authInp,
       [name]: value,

--- a/app/services/apiService.ts
+++ b/app/services/apiService.ts
@@ -1,6 +1,5 @@
 import axios from "axios";
 import { postRefreshToken } from "./auth";
-import { error } from "console";
 
 const BASE_URL = "http://52.78.93.9:8000";
 


### PR DESCRIPTION
메모 등록시 서버에서 날짜를 현재날짜로 생성하는 문제를 백엔드 개발자와 함께 수정하였고 이로인해, 메모등록 api호출 시 전달 객체에 created_at의 값도 넣어주는 것으로 변경하였습니다.